### PR TITLE
Add press-enter event to input fields

### DIFF
--- a/src/app/components/generics/property-input/text-input.component.html
+++ b/src/app/components/generics/property-input/text-input.component.html
@@ -8,6 +8,7 @@
       [(ngModel)]="value"
       matInput
       (click)="(isLink && !isBeingEdited && value) ? openLink() : false"
+      (keydown.enter)="toggleEdit()"
     />
     <textarea
       *ngIf="multiline"
@@ -16,6 +17,7 @@
       [matAutosizeMaxRows]="maxLines"
       [matAutosizeMinRows]="2"
       [matTextareaAutosize]="true"
+      (keydown.enter)="toggleEdit()"
       matInput
     ></textarea>
     <button

--- a/src/app/components/generics/property-input/text-input.component.html
+++ b/src/app/components/generics/property-input/text-input.component.html
@@ -17,7 +17,6 @@
       [matAutosizeMaxRows]="maxLines"
       [matAutosizeMinRows]="2"
       [matTextareaAutosize]="true"
-      (keydown.enter)="toggleEdit()"
       matInput
     ></textarea>
     <button


### PR DESCRIPTION
**Proposed Changes**

- Adds press-enter event to generic input fields

--> implements the following issue: [Save an input field change by Pressing Enter](https://github.com/UST-QuAntiL/q-tal/issues/73)