### PR TITLE
Fixed minor bugs in Pattern-Dialog

### DIFF
--- a/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
+++ b/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
@@ -8,6 +8,7 @@ import { PatternRelationDto } from 'api-atlas/models';
 import { PatternControllerService } from 'api-patternpedia/services/pattern-controller.service';
 import { EntityModelPattern } from 'api-patternpedia/models/entity-model-pattern';
 import { EntityModelPatternLanguage } from 'api-patternpedia/models';
+import { forkJoin } from 'rxjs';
 import { AddPatternRelationDialogComponent } from '../dialogs/add-pattern-relation-dialog.component';
 import { UtilService } from '../../../util/util.service';
 import { ConfirmDialogComponent } from '../../generics/dialogs/confirm-dialog.component';
@@ -190,18 +191,17 @@ export class AlgorithmRelatedPatternsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe((dialogResult) => {
       if (dialogResult) {
-        const promises: Array<Promise<void>> = [];
+        const deletionTasks = [];
+
         for (const relation of event.elements) {
-          promises.push(
-            this.algorithmService
-              .deletePatternRelationOfAlgorithm({
-                algorithmId: this.algorithm.id,
-                patternRelationId: relation.id,
-              })
-              .toPromise()
+          deletionTasks.push(
+            this.algorithmService.deletePatternRelationOfAlgorithm({
+              algorithmId: this.algorithm.id,
+              patternRelationId: relation.id,
+            })
           );
         }
-        Promise.all(promises).then(() => {
+        forkJoin(deletionTasks).subscribe(() => {
           this.getPatternRelations({ algorithmId: this.algorithm.id });
           this.utilService.callSnackBar(
             'Successfully removed pattern relation(s)'

--- a/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
+++ b/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
@@ -190,19 +190,23 @@ export class AlgorithmRelatedPatternsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe((dialogResult) => {
       if (dialogResult) {
+        const promises: Array<Promise<void>> = [];
         for (const relation of event.elements) {
-          this.algorithmService
-            .deletePatternRelationOfAlgorithm({
-              algorithmId: this.algorithm.id,
-              patternRelationId: relation.id,
-            })
-            .subscribe(() => {
-              this.getPatternRelations({ algorithmId: this.algorithm.id });
-              this.utilService.callSnackBar(
-                'Successfully removed pattern relation'
-              );
-            });
+          promises.push(
+            this.algorithmService
+              .deletePatternRelationOfAlgorithm({
+                algorithmId: this.algorithm.id,
+                patternRelationId: relation.id,
+              })
+              .toPromise()
+          );
         }
+        Promise.all(promises).then(() => {
+          this.getPatternRelations({ algorithmId: this.algorithm.id });
+          this.utilService.callSnackBar(
+            'Successfully removed pattern relation(s)'
+          );
+        });
       }
     });
   }

--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.html
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.html
@@ -33,8 +33,7 @@
       </div>
     </div>
     <div class="mt-2">
-      <button class="step-button" mat-stroked-button matStepperNext [disabled]="!selectedPatternLanguage"
-              (click)="getPatterns(selectedPatternLanguage.id)">
+      <button class="step-button" mat-stroked-button matStepperNext [disabled]="!selectedPatternLanguage">
         <mat-icon>navigate_next</mat-icon>
       </button>
     </div>
@@ -71,11 +70,10 @@
     </div>
     <div class="mt-2">
       <button class="step-button" mat-stroked-button matStepperPrevious>
-        <mat-icon (click)="getPatternLanguages()">navigate_before</mat-icon>
+        <mat-icon>navigate_before</mat-icon>
       </button>
       <button class="step-button ml-1" mat-stroked-button matStepperNext
-              [disabled]="!selectedPatternLanguage || !selectedPattern"
-              (click)="getRelationTypes()">
+              [disabled]="!selectedPatternLanguage || !selectedPattern">
         <mat-icon>navigate_next</mat-icon>
       </button>
     </div>

--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
@@ -111,8 +111,12 @@ export class AddPatternRelationDialogComponent implements OnInit {
         this.patternLanguages = languages._embedded.patternLanguageModels;
         this.filteredPatternLanguages = this.patternLanguages;
         this.arePatternLanguagesLoaded = true;
+        // If pattern langauge is selected move it to front of list
         if (this.selectedPatternLanguage) {
-          this.patternLanguageSearch = this.selectedPatternLanguage.name;
+          this.reorderArray(
+            this.filteredPatternLanguages,
+            this.selectedPatternLanguage
+          );
         }
         this.onLanguageSearch();
       });
@@ -126,11 +130,18 @@ export class AddPatternRelationDialogComponent implements OnInit {
         this.patterns = patterns._embedded.patternModels;
         this.filteredPatterns = this.patterns;
         this.arePatternsLoaded = true;
+        // If pattern is selected move it to front of list
         if (this.selectedPattern) {
-          this.patternSearch = this.selectedPattern.name;
+          this.reorderArray(this.filteredPatterns, this.selectedPattern);
         }
         this.onPatternSearch();
       });
+  }
+
+  reorderArray(array: any[], element: any) {
+    array.sort((x, y) =>
+      x.id === element.id ? -1 : y.id === element.id ? 1 : 0
+    );
   }
 
   getRelationTypes(): void {
@@ -174,6 +185,8 @@ export class AddPatternRelationDialogComponent implements OnInit {
     } else {
       this.selectedPatternLanguage = undefined;
     }
+    // Unselect pattern after language was changed/unselected
+    this.selectedPattern = undefined;
   }
 
   onLanguageSearch(): void {


### PR DESCRIPTION
selecting/unselecting a language will now unselect the pattern since it wont be valid anymore. When a step is opened where the language or pattern was alredy selected, the selected pattern/language will be moved to front of the list

- Patterns and Languages will now not be fetched twice on step change
- Selecting/Unselecting a language will now unselect the pattern (since it wont be valid anymore)
- When returning to a finished step where the language or pattern was alredy selected, the selected pattern/language will be moved to front of the list
- Removal of PatternRelation now uses promises where it waits for all deletions to be processed before refreshing the list