### PR TITLE
Fixed display bugs with confirm deletion dialogs and url fields in data lists

### DIFF
--- a/src/app/components/algorithms/algorithm-publications-list/algorithm-publications-list.component.html
+++ b/src/app/components/algorithms/algorithm-publications-list/algorithm-publications-list.component.html
@@ -4,11 +4,13 @@
       [data]=linkObject.linkedData
       [variableNames]=variableNames
       [dataColumns]=tableColumns
+      [externalLinkVariables]=externalLinkVariables
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [allowSort]=true
       [emptyTableMessage]="'No linked publications found'"
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged($event)"
       (submitDeleteElements)="unlinkPublications($event)"
       (addElement)="openLinkPublicationDialog()">

--- a/src/app/components/algorithms/algorithm-publications-list/algorithm-publications-list.component.ts
+++ b/src/app/components/algorithms/algorithm-publications-list/algorithm-publications-list.component.ts
@@ -8,6 +8,7 @@ import { MatDialog } from '@angular/material/dialog';
 import {
   LinkObject,
   QueryParams,
+  UrlData,
 } from '../../generics/data-list/data-list.component';
 import { UtilService } from '../../../util/util.service';
 import { LinkItemListDialogComponent } from '../../generics/dialogs/link-item-list-dialog.component';
@@ -21,8 +22,9 @@ import { GenericDataService } from '../../../util/generic-data.service';
 export class AlgorithmPublicationsListComponent implements OnInit {
   @Input() algorithm: EntityModelAlgorithmDto;
 
-  variableNames: string[] = ['title', 'authors', 'doi'];
-  tableColumns: string[] = ['Title', 'Authors', 'DOI'];
+  variableNames: string[] = ['title', 'authors', 'doi', 'url'];
+  tableColumns: string[] = ['Title', 'Authors', 'DOI', 'URL'];
+  externalLinkVariables = ['url'];
   linkObject: LinkObject = {
     title: 'Link publication with ',
     subtitle: 'Search publications by title',
@@ -118,6 +120,11 @@ export class AlgorithmPublicationsListComponent implements OnInit {
 
   onElementClicked(publication: PublicationDto): void {
     this.routeToPublication(publication);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'url'
+    window.open(urlData.element['url'], '_blank');
   }
 
   routeToPublication(publication: PublicationDto): void {

--- a/src/app/components/algorithms/implementation-view/implementation-publications-list/implementation-publications-list.component.html
+++ b/src/app/components/algorithms/implementation-view/implementation-publications-list/implementation-publications-list.component.html
@@ -3,11 +3,13 @@
     <app-table
       [data]=linkObject.linkedData
       [variableNames]=variableNames
+      [externalLinkVariables]=externalLinkVariables
       [dataColumns]=tableColumns
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [emptyTableMessage]="'No linked publications found'"
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged($event)"
       (submitDeleteElements)="unlinkPublications($event)"
       (addElement)="openLinkPublicationDialog()">

--- a/src/app/components/algorithms/implementation-view/implementation-publications-list/implementation-publications-list.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-publications-list/implementation-publications-list.component.ts
@@ -8,7 +8,10 @@ import { MatDialog } from '@angular/material/dialog';
 import { GenericDataService } from '../../../../util/generic-data.service';
 import { UtilService } from '../../../../util/util.service';
 import { LinkItemListDialogComponent } from '../../../generics/dialogs/link-item-list-dialog.component';
-import { QueryParams } from '../../../generics/data-list/data-list.component';
+import {
+  QueryParams,
+  UrlData,
+} from '../../../generics/data-list/data-list.component';
 
 @Component({
   selector: 'app-implementation-publications-list',
@@ -20,6 +23,7 @@ export class ImplementationPublicationsListComponent implements OnInit {
 
   tableColumns = ['Title', 'URL', 'DOI', 'Authors'];
   variableNames = ['title', 'url', 'doi', 'authors'];
+  externalLinkVariables = ['url'];
   linkObject: any = {
     title: 'Link publication with ',
     subtitle: 'Search publication by title',
@@ -112,6 +116,11 @@ export class ImplementationPublicationsListComponent implements OnInit {
 
   onElementClicked(publication: any): void {
     this.routeToPublication(publication);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'url'
+    window.open(urlData.element['url'], '_blank');
   }
 
   routeToPublication(publication: PublicationDto): void {

--- a/src/app/components/algorithms/implementation-view/implementation-softwareplatform-list/implementation-softwareplatform-list.component.html
+++ b/src/app/components/algorithms/implementation-view/implementation-softwareplatform-list/implementation-softwareplatform-list.component.html
@@ -4,6 +4,7 @@
       [data]=linkObject.linkedData
       [variableNames]=variableNames
       [dataColumns]=tableColumns
+      [externalLinkVariables]=externalLinkVariables
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [allowSort]=true
@@ -11,6 +12,7 @@
       [pagination]=pagingInfo
       [paginatorConfig]=paginatorConfig
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged($event)"
       (submitDeleteElements)="unlinkSoftwarePlatforms($event)"
       (addElement)="openLinkSoftwarePlatformDialog()"

--- a/src/app/components/algorithms/implementation-view/implementation-softwareplatform-list/implementation-softwareplatform-list.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-softwareplatform-list/implementation-softwareplatform-list.component.ts
@@ -10,6 +10,7 @@ import { ComputeResourceDto } from 'api-atlas/models/compute-resource-dto';
 import {
   LinkObject,
   QueryParams,
+  UrlData,
 } from '../../../generics/data-list/data-list.component';
 import { UtilService } from '../../../../util/util.service';
 import { GenericDataService } from '../../../../util/generic-data.service';
@@ -26,6 +27,7 @@ export class ImplementationSoftwareplatformListComponent implements OnInit {
   publications: EntityModelSoftwarePlatformDto[];
   variableNames: string[] = ['name', 'link', 'license', 'version'];
   tableColumns: string[] = ['Name', 'Link', 'License', 'Version'];
+  externalLinkVariables = ['link'];
   linkObject: LinkObject = {
     title: 'Link software platform with ',
     subtitle: 'Search software platform by name',
@@ -197,6 +199,11 @@ export class ImplementationSoftwareplatformListComponent implements OnInit {
 
   onElementClicked(platform: any): void {
     this.routeToSoftwarePlatform(platform);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'link'
+    window.open(urlData.element['link'], '_blank');
   }
 
   routeToSoftwarePlatform(softwarePlatform: SoftwarePlatformDto): void {

--- a/src/app/components/execution-environments/cloud-services/cloud-service-list/cloud-service-list.component.html
+++ b/src/app/components/execution-environments/cloud-services/cloud-service-list/cloud-service-list.component.html
@@ -12,6 +12,7 @@
                [paginatorConfig]=paginatorConfig
                [emptyTableMessage]="'No cloud services found'"
                (elementClicked)="onCloudServiceClicked($event)"
+               (urlClicked)="onUrlClicked($event)"
                (addElement)="onCreateCloudService()"
                (submitDeleteElements)="onDeleteCloudServices($event)"
                (datalistConfigChanged)="getCloudServices($event)"

--- a/src/app/components/execution-environments/cloud-services/cloud-service-list/cloud-service-list.component.ts
+++ b/src/app/components/execution-environments/cloud-services/cloud-service-list/cloud-service-list.component.ts
@@ -7,6 +7,7 @@ import { UtilService } from '../../../../util/util.service';
 import {
   SelectParams,
   QueryParams,
+  UrlData,
 } from '../../../generics/data-list/data-list.component';
 import { CreateCloudServiceDialogComponent } from '../dialogs/create-cloud-service-dialog.component';
 import { GenericDataService } from '../../../../util/generic-data.service';
@@ -68,6 +69,11 @@ export class CloudServiceListComponent implements OnInit {
       'cloud-services',
       cloudService.id,
     ]);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'url'
+    window.open(urlData.element['url'], '_blank');
   }
 
   onCreateCloudService(): void {

--- a/src/app/components/execution-environments/cloud-services/cloud-service-software-platform-list/cloud-service-software-platform-list.component.html
+++ b/src/app/components/execution-environments/cloud-services/cloud-service-software-platform-list/cloud-service-software-platform-list.component.html
@@ -3,12 +3,14 @@
     <app-table
       [data]=linkObject.linkedData
       [variableNames]=variableNames
+      [externalLinkVariables]=externalLinkVariables
       [dataColumns]=tableColumns
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [allowSort]=true
       [emptyTableMessage]="'No linked software platforms found'"
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged()"
       (submitDeleteElements)="unlinkSoftwarePlatforms($event)"
       (addElement)="openLinkSoftwarePlatformDialog()">

--- a/src/app/components/execution-environments/cloud-services/cloud-service-software-platform-list/cloud-service-software-platform-list.component.ts
+++ b/src/app/components/execution-environments/cloud-services/cloud-service-software-platform-list/cloud-service-software-platform-list.component.ts
@@ -9,6 +9,7 @@ import {
   SelectParams,
   LinkObject,
   QueryParams,
+  UrlData,
 } from '../../../generics/data-list/data-list.component';
 import { UtilService } from '../../../../util/util.service';
 import { GenericDataService } from '../../../../util/generic-data.service';
@@ -24,6 +25,7 @@ export class CloudServiceSoftwarePlatformListComponent implements OnInit {
 
   tableColumns = ['Name', 'Version', 'Licence', 'Link'];
   variableNames = ['name', 'version', 'licence', 'link'];
+  externalLinkVariables = ['link'];
   linkObject: LinkObject = {
     title: 'Link software platform with ',
     subtitle: 'Search software platform by name',
@@ -186,6 +188,11 @@ export class CloudServiceSoftwarePlatformListComponent implements OnInit {
 
   onElementClicked(softwarePlatform: SoftwarePlatformDto): void {
     this.routeToSoftwarePlatform(softwarePlatform);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'link'
+    window.open(urlData.element['link'], '_blank');
   }
 
   routeToSoftwarePlatform(softwarePlatform: SoftwarePlatformDto): void {

--- a/src/app/components/execution-environments/compute-resource/compute-resource-cloud-service-list/compute-resource-cloud-service-list.component.html
+++ b/src/app/components/execution-environments/compute-resource/compute-resource-cloud-service-list/compute-resource-cloud-service-list.component.html
@@ -3,11 +3,13 @@
     <app-table
       [data]=linkObject.linkedData
       [variableNames]=variableNames
+      [externalLinkVariables]=externalLinkVariables
       [dataColumns]=tableColumns
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [emptyTableMessage]="'No linked cloud services found'"
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged()"
       (submitDeleteElements)="unlinkCloudServices($event)"
       (addElement)="openLinkCloudServiceDialog()">

--- a/src/app/components/execution-environments/compute-resource/compute-resource-cloud-service-list/compute-resource-cloud-service-list.component.ts
+++ b/src/app/components/execution-environments/compute-resource/compute-resource-cloud-service-list/compute-resource-cloud-service-list.component.ts
@@ -8,6 +8,7 @@ import {
   SelectParams,
   LinkObject,
   QueryParams,
+  UrlData,
 } from '../../../generics/data-list/data-list.component';
 import { UtilService } from '../../../../util/util.service';
 import { LinkItemListDialogComponent } from '../../../generics/dialogs/link-item-list-dialog.component';
@@ -22,7 +23,8 @@ export class ComputeResourceCloudServiceListComponent implements OnInit {
   @Input() computeResource: EntityModelComputeResourceDto;
 
   tableColumns = ['Name', 'Provider', 'Description', 'CostModel', 'URL'];
-  variableNames = ['name', 'provider', 'description', 'costModel', 'URL'];
+  variableNames = ['name', 'provider', 'description', 'costModel', 'url'];
+  externalLinkVariables = ['url'];
   linkObject: LinkObject = {
     title: 'Link cloud service with ',
     subtitle: 'Search cloud services by name',
@@ -184,6 +186,11 @@ export class ComputeResourceCloudServiceListComponent implements OnInit {
 
   onElementClicked(cloudService: CloudServiceDto): void {
     this.routeToCloudService(cloudService);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'url'
+    window.open(urlData.element['url'], '_blank');
   }
 
   private routeToCloudService(cloudService: CloudServiceDto) {

--- a/src/app/components/execution-environments/compute-resource/compute-resource-list/compute-resource-list.component.ts
+++ b/src/app/components/execution-environments/compute-resource/compute-resource-list/compute-resource-list.component.ts
@@ -108,7 +108,7 @@ export class ComputeResourceListComponent implements OnInit {
         message:
           'Are you sure you want to delete the following compute resource(s): ',
         data: deleteParams.elements,
-        variableName: 'title',
+        variableName: 'name',
         yesButtonText: 'yes',
         noButtonText: 'no',
       })

--- a/src/app/components/execution-environments/compute-resource/compute-resource-software-platform-list/compute-resource-software-platform-list.component.html
+++ b/src/app/components/execution-environments/compute-resource/compute-resource-software-platform-list/compute-resource-software-platform-list.component.html
@@ -3,11 +3,13 @@
     <app-table
       [data]=linkObject.linkedData
       [variableNames]=variableNames
+      [externalLinkVariables]=externalLinkVariables
       [dataColumns]=tableColumns
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [emptyTableMessage]="'No linked software platforms found'"
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged()"
       (submitDeleteElements)="unlinkSoftwarePlatforms($event)"
       (addElement)="openLinkSoftwarePlatformDialog()">

--- a/src/app/components/execution-environments/compute-resource/compute-resource-software-platform-list/compute-resource-software-platform-list.component.ts
+++ b/src/app/components/execution-environments/compute-resource/compute-resource-software-platform-list/compute-resource-software-platform-list.component.ts
@@ -9,6 +9,7 @@ import {
   SelectParams,
   LinkObject,
   QueryParams,
+  UrlData,
 } from '../../../generics/data-list/data-list.component';
 import { UtilService } from '../../../../util/util.service';
 import { LinkItemListDialogComponent } from '../../../generics/dialogs/link-item-list-dialog.component';
@@ -24,6 +25,7 @@ export class ComputeResourceSoftwarePlatformListComponent implements OnInit {
 
   tableColumns = ['Name', 'Version', 'Licence', 'Link'];
   variableNames = ['name', 'version', 'licence', 'link'];
+  externalLinkVariables = ['link'];
   linkObject: LinkObject = {
     title: 'Link software platform with ',
     subtitle: 'Search software platform by name',
@@ -192,6 +194,11 @@ export class ComputeResourceSoftwarePlatformListComponent implements OnInit {
 
   onElementClicked(softwarePlatform: SoftwarePlatformDto): void {
     this.routeToSoftwarePlatform(softwarePlatform);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'link'
+    window.open(urlData.element['link'], '_blank');
   }
 
   routeToSoftwarePlatform(softwarePlatform: SoftwarePlatformDto): void {

--- a/src/app/components/execution-environments/software-platforms/software-platform-cloud-service-list/software-platform-cloud-service-list.component.html
+++ b/src/app/components/execution-environments/software-platforms/software-platform-cloud-service-list/software-platform-cloud-service-list.component.html
@@ -3,11 +3,13 @@
     <app-table
       [data]=linkObject.linkedData
       [variableNames]=variableNames
+      [externalLinkVariables]=externalLinkVariables
       [dataColumns]=tableColumns
       [allowAdd]=tableAddAllowed
       [allowDelete]="true"
       [emptyTableMessage]="'No linked cloud services found'"
       (elementClicked)="onElementClicked($event)"
+      (urlClicked)="onUrlClicked($event)"
       (datalistConfigChanged)="onDatalistConfigChanged()"
       (submitDeleteElements)="unlinkCloudServices($event)"
       (addElement)="openLinkCloudServiceDialog()">

--- a/src/app/components/execution-environments/software-platforms/software-platform-cloud-service-list/software-platform-cloud-service-list.component.ts
+++ b/src/app/components/execution-environments/software-platforms/software-platform-cloud-service-list/software-platform-cloud-service-list.component.ts
@@ -8,6 +8,7 @@ import {
   SelectParams,
   LinkObject,
   QueryParams,
+  UrlData,
 } from '../../../generics/data-list/data-list.component';
 import { UtilService } from '../../../../util/util.service';
 import { GenericDataService } from '../../../../util/generic-data.service';
@@ -22,7 +23,8 @@ export class SoftwarePlatformCloudServiceListComponent implements OnInit {
   @Input() softwarePlatform: EntityModelSoftwarePlatformDto;
 
   tableColumns = ['Name', 'Provider', 'Description', 'CostModel', 'URL'];
-  variableNames = ['name', 'provider', 'description', 'costModel', 'URL'];
+  variableNames = ['name', 'provider', 'description', 'costModel', 'url'];
+  externalLinkVariables = ['url'];
   linkObject: LinkObject = {
     title: 'Link cloud service with ',
     subtitle: 'Search cloud services by name',
@@ -188,6 +190,11 @@ export class SoftwarePlatformCloudServiceListComponent implements OnInit {
 
   onElementClicked(cloudService: CloudServiceDto): void {
     this.routeToCloudService(cloudService);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'url'
+    window.open(urlData.element['url'], '_blank');
   }
 
   private routeToCloudService(cloudService: CloudServiceDto) {

--- a/src/app/components/execution-environments/software-platforms/software-platform-list/software-platform-list.component.ts
+++ b/src/app/components/execution-environments/software-platforms/software-platform-list/software-platform-list.component.ts
@@ -115,7 +115,7 @@ export class SoftwarePlatformListComponent implements OnInit {
         message:
           'Are you sure you want to delete the following software platform(s): ',
         data: deleteParams.elements,
-        variableName: 'title',
+        variableName: 'name',
         yesButtonText: 'yes',
         noButtonText: 'no',
       })


### PR DESCRIPTION
This PR fixes the following bugs:
- Confirm Deletion dialogs will now correctly show the names/titles of the objects that were selected to be deleted instead of nothing
- URL fields on all datalists will be correctly displayed as URLs and will also be clickable and will open the URL in a new tab