### PR TITLE
Fix issues in the implementation/QPU selection criteria save logic

### DIFF
--- a/src/app/components/algorithms/impl-selection-criteria/impl-selection-criteria.component.ts
+++ b/src/app/components/algorithms/impl-selection-criteria/impl-selection-criteria.component.ts
@@ -120,17 +120,18 @@ export class ImplSelectionCriteriaComponent implements OnInit, OnChanges {
         )
       )
     );
-    const updatedImpl$ = allAddedParams$.pipe(
-      switchMap(() =>
-        this.nisqImplementationService.updateImplementation({
-          implId: this.nisqImpl.id,
-          body: this.nisqImpl,
-        })
-      )
-    );
-    updatedImpl$.subscribe((impl) => {
-      this.nisqImpl = impl;
-      this.oldNisqImpl = cloneDeep(impl);
+    allAddedParams$.subscribe({
+      complete: () => {
+        this.nisqImplementationService
+          .updateImplementation({
+            implId: this.nisqImpl.id,
+            body: this.nisqImpl,
+          })
+          .subscribe((impl) => {
+            this.nisqImpl = impl;
+            this.oldNisqImpl = cloneDeep(impl);
+          });
+      },
     });
   }
 
@@ -147,6 +148,7 @@ export class ImplSelectionCriteriaComponent implements OnInit, OnChanges {
       .createImplementation({ body })
       .subscribe((newImpl) => {
         this.nisqImpl = newImpl;
+        this.oldNisqImpl = cloneDeep(newImpl);
         this.selection.clear();
       });
   }

--- a/src/app/components/execution-environments/compute-resource/compute-resource-selection-criteria/compute-resource-selection-criteria.component.ts
+++ b/src/app/components/execution-environments/compute-resource/compute-resource-selection-criteria/compute-resource-selection-criteria.component.ts
@@ -71,6 +71,7 @@ export class ComputeResourceSelectionCriteriaComponent implements OnInit {
       };
       this.nisqQpuService.createQpu({ body }).subscribe((newQpu) => {
         this.qpu = newQpu;
+        this.oldQpu = cloneDeep(newQpu);
       });
     });
   }


### PR DESCRIPTION
We can't use `.pipe()` for the param add/del observable since it might be empty,
which means there's no next value and thus the implementation update never happens.