### PR TITLE
Fixed bugs in AlgorithmRelation-Dialog

### DIFF
--- a/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.ts
@@ -63,11 +63,9 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
     this.algoRelationTypeService
       .getAlgorithmRelationTypes()
       .subscribe((relationTypes) => {
-        if (relationTypes._embedded) {
-          this.algoRelationTypes = relationTypes._embedded.algoRelationTypes;
-        } else {
-          this.algoRelationTypes = [];
-        }
+        this.algoRelationTypes = relationTypes._embedded
+          ? relationTypes._embedded.algoRelationTypes
+          : [];
         this.stateGroups.push({
           optionName: 'Existing Algorithm-Relations',
           algoRelationTypes: this.algoRelationTypes,

--- a/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.ts
@@ -65,14 +65,16 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
       .subscribe((relationTypes) => {
         if (relationTypes._embedded) {
           this.algoRelationTypes = relationTypes._embedded.algoRelationTypes;
-          this.stateGroups.push({
-            optionName: 'Existing Algorithm-Relations',
-            algoRelationTypes: this.algoRelationTypes,
-          });
-          // Set filtered Types if update-dialog
-          if (this.isUpdateDialog) {
-            this.filterTypes(this.relationType.value.name);
-          }
+        } else {
+          this.algoRelationTypes = [];
+        }
+        this.stateGroups.push({
+          optionName: 'Existing Algorithm-Relations',
+          algoRelationTypes: this.algoRelationTypes,
+        });
+        // Set filtered Types if update-dialog
+        if (this.isUpdateDialog) {
+          this.filterTypes(this.relationType.value.name);
         }
       });
 


### PR DESCRIPTION
Currently, the frontend has a bug with the AlgorithmRelationTypes in the AlgorithmRelation-Dialog in case no RelationTypes exist. It leads to the problem that the code tries to access the StateGroups at position "-1", because the code never creates a StateGroup for the existing RelationTypes (because they do not exist). This PR fixes this by creating an empty StateGroup for existing RelationTypes.