### PR TITLE
Link implementations to publications

### DIFF
--- a/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.html
+++ b/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.html
@@ -4,11 +4,12 @@
                [data]=linkedImplementations
                [variableNames]=variableNames
                [dataColumns]=tableColumns
-               [allowAdd]=true
+               [allowAdd]="true"
                [allowDelete]="true"
                [emptyTableMessage]="'No linked implementations found'"
                (elementClicked)="onElementClicked($event)"
-               (datalistConfigChanged)="onDatalistConfigChanged($event)">
+               (datalistConfigChanged)="onDatalistConfigChanged($event)"
+               (addElement)="openLinkImplementationDialog()">
     </app-table>
   </div>
 </mat-card>

--- a/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.html
+++ b/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.html
@@ -4,6 +4,8 @@
                [data]=linkedImplementations
                [variableNames]=variableNames
                [dataColumns]=tableColumns
+               [allowAdd]=true
+               [allowDelete]="true"
                [emptyTableMessage]="'No linked implementations found'"
                (elementClicked)="onElementClicked($event)"
                (datalistConfigChanged)="onDatalistConfigChanged($event)">

--- a/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.ts
+++ b/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.ts
@@ -28,7 +28,7 @@ export class PublicationImplementationsListComponent implements OnInit {
   ];
   tableAddAllowed = true;
   linkObject: any = {
-    title: 'Link implementation with ',
+    title: 'Link publication with ',
     subtitle: 'Search implementation by name',
     displayVariable: 'name',
     data: [],
@@ -50,24 +50,28 @@ export class PublicationImplementationsListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.getLinkedImplementations();
+    this.getLinkedImplementations({ publicationId: this.publication.id });
   }
 
   onDatalistConfigChanged(event): void {
-    this.getLinkedImplementations();
+    this.getLinkedImplementations({ publicationId: this.publication.id });
   }
 
-  getLinkedImplementations(): void {
+  getLinkedImplementations(params: {
+    publicationId: string;
+    search?: string;
+    page?: number;
+    size?: number;
+    sort?: string[];
+  }): void {
     this.publicationService
-      .getImplementationsOfPublication({
-        publicationId: this.publication.id,
-      })
-      .subscribe((implementations) => {
-        console.log(implementations);
-        this.linkObject.linkedData = [];
-        if (implementations._embedded) {
-          this.linkObject.linkedData =
-            implementations._embedded.implementations;
+      .getImplementationsOfPublication(params)
+      .subscribe((data) => {
+        // Read all incoming data
+        if (data._embedded) {
+          this.linkedImplementations = data._embedded.implementations;
+        } else {
+          this.linkedImplementations = [];
         }
       });
   }
@@ -92,7 +96,7 @@ export class PublicationImplementationsListComponent implements OnInit {
         body: this.publication,
       })
       .subscribe(() => {
-        this.getLinkedImplementations();
+        this.getLinkedImplementations({ publicationId: this.publication.id });
         this.utilService.callSnackBar('Successfully linked Implementation');
       });
   }
@@ -107,6 +111,7 @@ export class PublicationImplementationsListComponent implements OnInit {
     this.pagingInfo.page = data.page;
     this.pagingInfo._links = data._links;
   }
+
   unlinkImplementations(event): void {
     const promises: Array<Promise<void>> = [];
     for (const implementation of event.elements) {
@@ -121,7 +126,7 @@ export class PublicationImplementationsListComponent implements OnInit {
       );
     }
     Promise.all(promises).then(() => {
-      this.getLinkedImplementations();
+      this.getLinkedImplementations({ publicationId: this.publication.id });
       this.utilService.callSnackBar('Successfully unlinked implementation(s)');
     });
   }
@@ -148,8 +153,6 @@ export class PublicationImplementationsListComponent implements OnInit {
             'assumptions',
             'link',
           ],
-          pagingInfo: this.pagingInfo,
-          paginatorConfig: this.paginatorConfig,
           noButtonText: 'Cancel',
         },
       });

--- a/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.ts
+++ b/src/app/components/publications/publication-implementations-list/publication-implementations-list.component.ts
@@ -5,6 +5,10 @@ import { PublicationService } from 'api-atlas/services/publication.service';
 import { AlgorithmService } from 'api-atlas/services/algorithm.service';
 import { EntityModelImplementationDto } from 'api-atlas/models/entity-model-implementation-dto';
 import { ImplementationDto } from 'api-atlas/models/implementation-dto';
+import { ImplementationService } from 'api-nisq/services/implementation.service';
+import { MatDialog } from '@angular/material/dialog';
+import { UtilService } from '../../../util/util.service';
+import { LinkItemListDialogComponent } from '../../generics/dialogs/link-item-list-dialog.component';
 
 @Component({
   selector: 'app-publication-implementations-list',
@@ -22,36 +26,48 @@ export class PublicationImplementationsListComponent implements OnInit {
     'assumptions',
     'link',
   ];
+  tableAddAllowed = true;
+  linkObject: any = {
+    title: 'Link implementation with ',
+    subtitle: 'Search implementation by name',
+    displayVariable: 'name',
+    data: [],
+    linkedData: [],
+  };
+  pagingInfo: any = {};
+  paginatorConfig: any = {
+    amountChoices: [10, 25, 50],
+    selectedAmount: 10,
+  };
 
   constructor(
     private publicationService: PublicationService,
     private algorithmService: AlgorithmService,
-    private router: Router
+    private implementationService: ImplementationService,
+    private utilService: UtilService,
+    private router: Router,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
-    this.getLinkedImplementations({ publicationId: this.publication.id });
+    this.getLinkedImplementations();
   }
 
   onDatalistConfigChanged(event): void {
-    this.getLinkedImplementations({ publicationId: this.publication.id });
+    this.getLinkedImplementations();
   }
 
-  getLinkedImplementations(params: {
-    publicationId: string;
-    search?: string;
-    page?: number;
-    size?: number;
-    sort?: string[];
-  }): void {
+  getLinkedImplementations(): void {
     this.publicationService
-      .getImplementationsOfPublication(params)
-      .subscribe((data) => {
-        // Read all incoming data
-        if (data._embedded) {
-          this.linkedImplementations = data._embedded.implementations;
-        } else {
-          this.linkedImplementations = [];
+      .getImplementationsOfPublication({
+        publicationId: this.publication.id,
+      })
+      .subscribe((implementations) => {
+        console.log(implementations);
+        this.linkObject.linkedData = [];
+        if (implementations._embedded) {
+          this.linkObject.linkedData =
+            implementations._embedded.implementations;
         }
       });
   }
@@ -63,5 +79,82 @@ export class PublicationImplementationsListComponent implements OnInit {
       'implementations',
       implementation.id,
     ]);
+  }
+
+  linkImplementation(implementation: ImplementationDto): void {
+    // Empty unlinked implementations
+    this.linkObject.data = [];
+    // Link algorithm
+    this.algorithmService
+      .linkImplementationAndPublication({
+        algorithmId: implementation.implementedAlgorithmId,
+        implementationId: implementation.id,
+        body: this.publication,
+      })
+      .subscribe(() => {
+        this.getLinkedImplementations();
+        this.utilService.callSnackBar('Successfully linked Implementation');
+      });
+  }
+
+  updateImplementationData(data): void {
+    // clear link object data
+    this.linkObject.data = [];
+    // If implementations found
+    if (data._embedded) {
+      this.linkObject.data = data._embedded.implementations;
+    }
+    this.pagingInfo.page = data.page;
+    this.pagingInfo._links = data._links;
+  }
+  unlinkImplementations(event): void {
+    const promises: Array<Promise<void>> = [];
+    for (const implementation of event.elements) {
+      promises.push(
+        this.algorithmService
+          .unlinkImplementationAndPublication({
+            algorithmId: implementation.implementedAlgorithmId,
+            implementationId: implementation.id,
+            publicationId: this.publication.id,
+          })
+          .toPromise()
+      );
+    }
+    Promise.all(promises).then(() => {
+      this.getLinkedImplementations();
+      this.utilService.callSnackBar('Successfully unlinked implementation(s)');
+    });
+  }
+
+  openLinkImplementationDialog() {
+    this.implementationService.getImplementations().subscribe((data) => {
+      this.updateImplementationData(data);
+      const dialogRef = this.dialog.open(LinkItemListDialogComponent, {
+        width: '800px',
+        data: {
+          title: 'Link existing implementation',
+          linkObject: this.linkObject,
+          tableColumns: [
+            'Name',
+            'Description',
+            'Contributors',
+            'Assumptions',
+            'Link',
+          ],
+          variableNames: [
+            'name',
+            'description',
+            'contributors',
+            'assumptions',
+            'link',
+          ],
+          pagingInfo: this.pagingInfo,
+          paginatorConfig: this.paginatorConfig,
+          noButtonText: 'Cancel',
+        },
+      });
+
+      dialogRef.afterClosed().subscribe((dialogResult) => {});
+    });
   }
 }


### PR DESCRIPTION
Adds the functionality to link implementations to publications in the publication object view.

Solves the following issue: [#84](https://github.com/UST-QuAntiL/qc-atlas-ui/issues/84)

Fixes #84