### PR TITLE
Added error handling if no pattern languages or patterns are returned

### DIFF
--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.html
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.html
@@ -30,6 +30,7 @@
             </div>
           </mat-card>
         </ng-container>
+        <div class="emptyListError" *ngIf="patternLanguages.length === 0 && arePatternLanguagesLoaded">No pattern languages available!</div>
       </div>
     </div>
     <div class="mt-2">
@@ -66,6 +67,7 @@
             </div>
           </mat-card>
         </ng-container>
+        <div class="emptyListError" *ngIf="patterns.length === 0 && arePatternsLoaded">No patterns available!</div>
       </div>
     </div>
     <div class="mt-2">

--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.scss
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.scss
@@ -77,3 +77,7 @@
 .actions-container {
   height: 10%;
 }
+
+.emptyListError {
+  margin: auto;
+}

--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
@@ -108,7 +108,9 @@ export class AddPatternRelationDialogComponent implements OnInit {
     this.patternLanguageService
       .getAllPatternLanguageModels()
       .subscribe((languages) => {
-        this.patternLanguages = languages._embedded.patternLanguageModels;
+        this.patternLanguages = languages._embedded
+          ? languages._embedded.patternLanguageModels
+          : [];
         this.filteredPatternLanguages = this.patternLanguages;
         this.arePatternLanguagesLoaded = true;
         // If pattern langauge is selected move it to front of list
@@ -127,7 +129,9 @@ export class AddPatternRelationDialogComponent implements OnInit {
     this.patternService
       .getPatternsOfPatternLanguage({ patternLanguageId })
       .subscribe((patterns) => {
-        this.patterns = patterns._embedded.patternModels;
+        this.patterns = patterns._embedded
+          ? patterns._embedded.patternModels
+          : [];
         this.filteredPatterns = this.patterns;
         this.arePatternsLoaded = true;
         // If pattern is selected move it to front of list

--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
@@ -114,7 +114,7 @@ export class AddPatternRelationDialogComponent implements OnInit {
           : [];
         this.filteredPatternLanguages = this.patternLanguages;
         this.arePatternLanguagesLoaded = true;
-        // If pattern langauge is selected move it to front of list
+        // If pattern language is selected move it to front of list
         if (this.selectedPatternLanguage) {
           this.reorderArray(
             this.filteredPatternLanguages,

--- a/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-pattern-relation-dialog.component.ts
@@ -11,6 +11,7 @@ import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import { EntityModelPatternModel } from 'api-patternpedia/models/entity-model-pattern-model';
 import { environment as Env } from '../../../../environments/environment';
+import { UtilService } from '../../../util/util.service';
 
 @Component({
   selector: 'app-add-pattern-relation-dialog',
@@ -51,6 +52,7 @@ export class AddPatternRelationDialogComponent implements OnInit {
     private patternRelationTypeService: PatternRelationTypeService,
     private patternLanguageService: PatternLanguageControllerService,
     private patternService: PatternControllerService,
+    private utilService: UtilService,
     public dialogRef: MatDialogRef<AddPatternRelationDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: DialogData
   ) {}
@@ -105,9 +107,8 @@ export class AddPatternRelationDialogComponent implements OnInit {
 
   getPatternLanguages(): void {
     this.arePatternLanguagesLoaded = false;
-    this.patternLanguageService
-      .getAllPatternLanguageModels()
-      .subscribe((languages) => {
+    this.patternLanguageService.getAllPatternLanguageModels().subscribe(
+      (languages) => {
         this.patternLanguages = languages._embedded
           ? languages._embedded.patternLanguageModels
           : [];
@@ -121,25 +122,44 @@ export class AddPatternRelationDialogComponent implements OnInit {
           );
         }
         this.onLanguageSearch();
-      });
+      },
+      () => {
+        this.arePatternLanguagesLoaded = true;
+        this.patternLanguages = [];
+        this.filteredPatternLanguages = this.patternLanguages;
+        this.utilService.callSnackBar(
+          'Error! Could not retrieve pattern languages from patternpedia.'
+        );
+      }
+    );
   }
 
   getPatterns(patternLanguageId: string): void {
     this.arePatternsLoaded = false;
     this.patternService
       .getPatternsOfPatternLanguage({ patternLanguageId })
-      .subscribe((patterns) => {
-        this.patterns = patterns._embedded
-          ? patterns._embedded.patternModels
-          : [];
-        this.filteredPatterns = this.patterns;
-        this.arePatternsLoaded = true;
-        // If pattern is selected move it to front of list
-        if (this.selectedPattern) {
-          this.reorderArray(this.filteredPatterns, this.selectedPattern);
+      .subscribe(
+        (patterns) => {
+          this.patterns = patterns._embedded
+            ? patterns._embedded.patternModels
+            : [];
+          this.filteredPatterns = this.patterns;
+          this.arePatternsLoaded = true;
+          // If pattern is selected move it to front of list
+          if (this.selectedPattern) {
+            this.reorderArray(this.filteredPatterns, this.selectedPattern);
+          }
+          this.onPatternSearch();
+        },
+        () => {
+          this.arePatternsLoaded = true;
+          this.patterns = [];
+          this.filteredPatterns = this.patterns;
+          this.utilService.callSnackBar(
+            'Error! Could not retrieve patterns from patternpedia.'
+          );
         }
-        this.onPatternSearch();
-      });
+      );
   }
 
   reorderArray(array: any[], element: any) {


### PR DESCRIPTION
Currently, or frontend does not handle empty responses from the pattern atlas when he does not return any patterns or pattern languages. This PR fixes this issue: https://github.com/UST-QuAntiL/qc-atlas-ui/issues/92