### PR TITLE
Fixed scrollbar issue with text-areas

### DIFF
--- a/src/app/components/generics/property-input/text-input.component.html
+++ b/src/app/components/generics/property-input/text-input.component.html
@@ -15,9 +15,9 @@
       [(ngModel)]="inputValue"
       [pattern]="pattern"
       (ngModelChange)="inputChanged()"
-      [matAutosizeMaxRows]="maxLines"
-      [matAutosizeMinRows]="2"
-      [matTextareaAutosize]="true"
+      cdkTextareaAutosize
+      cdkAutosizeMinRows="1"
+      cdkAutosizeMaxRows="50"
       matInput
     ></textarea>
     <button

--- a/src/app/components/generics/property-input/text-input.component.html
+++ b/src/app/components/generics/property-input/text-input.component.html
@@ -15,9 +15,9 @@
       [(ngModel)]="inputValue"
       [pattern]="pattern"
       (ngModelChange)="inputChanged()"
-      cdkTextareaAutosize
-      cdkAutosizeMinRows="1"
-      cdkAutosizeMaxRows="50"
+      [matAutosizeMaxRows]="maxLines"
+      [matAutosizeMinRows]="1"
+      [matTextareaAutosize]="true"
       matInput
     ></textarea>
     <button

--- a/src/app/components/generics/property-input/text-input.component.scss
+++ b/src/app/components/generics/property-input/text-input.component.scss
@@ -24,4 +24,10 @@
 
 mat-form-field {
   min-width: 100%;
+  line-height: normal;
+}
+
+textarea.mat-input-element {
+  padding: 0;
+  margin: 0;
 }


### PR DESCRIPTION
Currently, if a textarea contains enough text so multiple lines are needed, a scrollbar appears which is not necessary. This PR fixes this issue.

See issue: https://github.com/UST-QuAntiL/qc-atlas-ui/issues/82