### PR TITLE
add proxy to docker

### DIFF
--- a/.docker/nginx_default.conf
+++ b/.docker/nginx_default.conf
@@ -1,0 +1,50 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location /api {
+        proxy_pass https://api.quantum-computing.ibm.com;
+        proxy_ssl_server_name on;
+        proxy_set_header Origin https://api.quantum-computing.ibm.com;
+        proxy_hide_header Access-Control-Allow-Origin;
+        add_header Access-Control-Allow-Origin $http_origin;
+    }
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm install && npm run build --prod
 
 FROM nginx:alpine
 COPY --from=builder app/dist/* /usr/share/nginx/html
+COPY .docker/nginx_default.conf /etc/nginx/conf.d/default.conf
 
 ENV QC_ATLAS_HOST_NAME localhost
 ENV QC_ATLAS_PORT 6626


### PR DESCRIPTION
Add proxy to Dockerfile and nginx to support the call to IBMQ for getting queue lengths and avoid CORS errors