### PR TITLE
support inverseTypeName of AlgoRelationTypes

### DIFF
--- a/generated/api-atlas/models/algorithm-relation-dto.ts
+++ b/generated/api-atlas/models/algorithm-relation-dto.ts
@@ -5,5 +5,5 @@ export type AlgorithmRelationDto = {
   sourceAlgorithmId: string;
   targetAlgorithmId: string;
   description?: string;
-  algoRelationType: AlgorithmRelationTypeDto;
+  algorithmRelationType: AlgorithmRelationTypeDto;
 };

--- a/generated/api-atlas/models/algorithm-relation-type-dto.ts
+++ b/generated/api-atlas/models/algorithm-relation-type-dto.ts
@@ -1,2 +1,6 @@
 /* tslint:disable */
-export type AlgorithmRelationTypeDto = { id: string; name: string };
+export type AlgorithmRelationTypeDto = {
+  id: string;
+  name: string;
+  inverseTypeName?: string;
+};

--- a/src/app/components/algorithm-relation-types/algorithm-relation-types-list/algorithm-relation-types-list.component.ts
+++ b/src/app/components/algorithm-relation-types/algorithm-relation-types-list/algorithm-relation-types-list.component.ts
@@ -17,8 +17,8 @@ import { AddOrEditAlgorithmRelationTypeDialogComponent } from '../dialogs/add-or
 })
 export class AlgorithmRelationTypesListComponent implements OnInit {
   algorithmRelationTypes: any[] = [];
-  tableColumns = ['Name'];
-  variableNames = ['name'];
+  tableColumns = ['Name', 'Inverse Type Name'];
+  variableNames = ['name', 'inverseTypeName'];
   pagingInfo: any = {};
   paginatorConfig: any = {
     amountChoices: [10, 25, 50],
@@ -68,6 +68,7 @@ export class AlgorithmRelationTypesListComponent implements OnInit {
         const algorithmRelationType: AlgorithmRelationTypeDto = {
           id: undefined,
           name: dialogResult.name,
+          inverseTypeName: dialogResult.inverseTypeName,
         };
 
         params.body = algorithmRelationType;
@@ -167,6 +168,7 @@ export class AlgorithmRelationTypesListComponent implements OnInit {
         title: 'Edit algorithm relation type',
         id: event.id,
         name: event.name,
+        inverseTypeName: event.inverseTypeName,
       }
     );
 
@@ -175,6 +177,7 @@ export class AlgorithmRelationTypesListComponent implements OnInit {
         const updatedAlgorithmRelationType: AlgorithmRelationTypeDto = {
           id: dialogResult.id,
           name: dialogResult.name,
+          inverseTypeName: dialogResult.inverseTypeName,
         };
 
         const params: any = {

--- a/src/app/components/algorithm-relation-types/dialogs/add-or-edit-algorithm-relation-type-dialog/add-or-edit-algorithm-relation-type-dialog.component.html
+++ b/src/app/components/algorithm-relation-types/dialogs/add-or-edit-algorithm-relation-type-dialog/add-or-edit-algorithm-relation-type-dialog.component.html
@@ -7,6 +7,12 @@
         <input formControlName="algorithmRelationTypeName" matInput required/>
       </label>
     </mat-form-field>
+    <mat-form-field class="input-field">
+      <mat-label>Inverse Type Name</mat-label>
+      <label>
+        <input formControlName="inverseAlgorithmRelationTypeName" matInput/>
+      </label>
+    </mat-form-field>
   </form>
 </div>
 <div mat-dialog-actions>

--- a/src/app/components/algorithm-relation-types/dialogs/add-or-edit-algorithm-relation-type-dialog/add-or-edit-algorithm-relation-type-dialog.component.ts
+++ b/src/app/components/algorithm-relation-types/dialogs/add-or-edit-algorithm-relation-type-dialog/add-or-edit-algorithm-relation-type-dialog.component.ts
@@ -26,6 +26,12 @@ export class AddOrEditAlgorithmRelationTypeDialogComponent implements OnInit {
     return this.algorithmRelationTypeFormGroup.get('algorithmRelationTypeName');
   }
 
+  get inverseAlgorithmRelationTypeName(): AbstractControl | null {
+    return this.algorithmRelationTypeFormGroup.get(
+      'inverseAlgorithmRelationTypeName'
+    );
+  }
+
   onNoClick(): void {
     this.dialogRef.close();
   }
@@ -37,10 +43,18 @@ export class AddOrEditAlgorithmRelationTypeDialogComponent implements OnInit {
         Validators.required,
         Validators.maxLength(255),
       ]),
+      inverseAlgorithmRelationTypeName: new FormControl(
+        this.data.inverseTypeName,
+        [
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          Validators.maxLength(255),
+        ]
+      ),
     });
 
     this.dialogRef.beforeClosed().subscribe(() => {
       this.data.name = this.algorithmRelationTypeName.value;
+      this.data.inverseTypeName = this.inverseAlgorithmRelationTypeName.value;
     });
   }
 
@@ -53,4 +67,5 @@ export interface DialogData {
   title: string;
   id: string;
   name: string;
+  inverseTypeName: string;
 }

--- a/src/app/components/algorithms/algorithm-related-algos-list/algorithm-related-algos-list.component.ts
+++ b/src/app/components/algorithms/algorithm-related-algos-list/algorithm-related-algos-list.component.ts
@@ -231,7 +231,14 @@ export class AlgorithmRelatedAlgosListComponent implements OnInit {
             ) {
               event.queryParams.page--;
             }
-            this.getAlgorithmRelations(event.queryParams);
+            debugger;
+            this.getAlgorithmRelations({
+              algorithmId: this.algorithm.id,
+              search: event.queryParams.search,
+              page: event.queryParams.page,
+              size: event.queryParams.size,
+              sort: event.queryParams.sort,
+            });
             snackbarMessages.push(
               this.utilService.generateFinishingSnackbarMessage(
                 successfulUnlinks,

--- a/src/app/components/algorithms/algorithm-related-algos-list/algorithm-related-algos-list.component.ts
+++ b/src/app/components/algorithms/algorithm-related-algos-list/algorithm-related-algos-list.component.ts
@@ -231,7 +231,6 @@ export class AlgorithmRelatedAlgosListComponent implements OnInit {
             ) {
               event.queryParams.page--;
             }
-            debugger;
             this.getAlgorithmRelations({
               algorithmId: this.algorithm.id,
               search: event.queryParams.search,

--- a/src/app/components/algorithms/algorithm-related-algos-list/algorithm-related-algos-list.component.ts
+++ b/src/app/components/algorithms/algorithm-related-algos-list/algorithm-related-algos-list.component.ts
@@ -331,8 +331,8 @@ export class AlgorithmRelatedAlgosListComponent implements OnInit {
             description: relation.description,
             targetAlgName: algorithm.name,
             targetAlgObject: algorithm,
-            relationTypeName: relation.algoRelationType.name,
-            relationTypeObject: relation.algoRelationType,
+            relationTypeName: relation.algorithmRelationType.name,
+            relationTypeObject: relation.algorithmRelationType,
           });
         });
     }
@@ -347,14 +347,14 @@ export class AlgorithmRelatedAlgosListComponent implements OnInit {
     id: string,
     sourceAlgorithm: AlgorithmDto,
     targetAlgorithm: AlgorithmDto,
-    algoRelationType: AlgorithmRelationTypeDto,
+    algorithmRelationType: AlgorithmRelationTypeDto,
     description: string
   ): AlgorithmRelationDto {
     return {
       id,
       sourceAlgorithmId: sourceAlgorithm.id,
       targetAlgorithmId: targetAlgorithm.id,
-      algoRelationType,
+      algorithmRelationType,
       description,
     };
   }

--- a/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.html
+++ b/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.html
@@ -35,7 +35,7 @@
       <mat-autocomplete #relationType="matAutocomplete" (optionSelected)="setRelationType($event.option.value)" [displayWith]="displayRelation">
         <mat-optgroup *ngFor="let stateGroup of stateGroups" [label]="stateGroup.optionName">
           <mat-option
-            *ngFor="let type of stateGroup.algoRelationTypes"
+            *ngFor="let type of stateGroup.algorithmRelationTypes"
             [value]="type"
             (click)="setRelationType(type)">
             {{type.name}}

--- a/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/add-algorithm-relation-dialog.component.ts
@@ -20,14 +20,14 @@ import { AlgorithmRelationTypeDto } from 'api-atlas/models';
 export class AddAlgorithmRelationDialogComponent implements OnInit {
   algorithmRelationForm: FormGroup;
   stateGroups: StateGroup[] = [];
-  algoRelationTypes: AlgorithmRelationTypeDto[] = [];
+  algorithmRelationTypes: AlgorithmRelationTypeDto[] = [];
   linkableAlgorithms: AlgorithmDto[] = [];
   selectedAlgorithm: AlgorithmDto;
   isUpdateDialog = false;
 
   constructor(
     private algorithmService: AlgorithmService,
-    private algoRelationTypeService: AlgorithmRelationTypeService,
+    private algorithmRelationTypeService: AlgorithmRelationTypeService,
     public dialogRef: MatDialogRef<AddAlgorithmRelationDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: DialogData
   ) {}
@@ -60,15 +60,15 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
     }
 
     // Init list of available relation types
-    this.algoRelationTypeService
+    this.algorithmRelationTypeService
       .getAlgorithmRelationTypes()
       .subscribe((relationTypes) => {
-        this.algoRelationTypes = relationTypes.content
+        this.algorithmRelationTypes = relationTypes.content
           ? relationTypes.content
           : [];
         this.stateGroups.push({
           optionName: 'Existing Algorithm-Relations',
-          algoRelationTypes: this.algoRelationTypes,
+          algorithmRelationTypes: this.algorithmRelationTypes,
         });
         // Set filtered Types if update-dialog
         if (this.isUpdateDialog) {
@@ -89,7 +89,7 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
   filterTypes(type: string): void {
     this.stateGroups[
       this.stateGroups.length - 1
-    ].algoRelationTypes = this.algoRelationTypes.filter(
+    ].algorithmRelationTypes = this.algorithmRelationTypes.filter(
       (filterType) =>
         filterType.name.toLowerCase().indexOf(type.toLowerCase()) === 0
     );
@@ -106,7 +106,7 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
   }
 
   findObjectByName(name): AlgorithmRelationTypeDto {
-    const foundType = this.algoRelationTypes.find((x) => x.name === name);
+    const foundType = this.algorithmRelationTypes.find((x) => x.name === name);
     return foundType ? foundType : { id: null, name };
   }
 
@@ -200,7 +200,7 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
     // Filter existing types
     this.filterTypes(searchType.name);
     // Return Type from Input if it exists
-    const existingRelationType = this.algoRelationTypes.find(
+    const existingRelationType = this.algorithmRelationTypes.find(
       (x) => x.name === searchType.name
     );
 
@@ -210,7 +210,7 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
       if (this.algoTypesNotEmpty() || this.isFirstTypeNew()) {
         this.pushNewRelationType(searchType);
       } else if (!this.isFirstTypeNew()) {
-        this.stateGroups[0].algoRelationTypes[0] = searchType;
+        this.stateGroups[0].algorithmRelationTypes[0] = searchType;
       }
     } else {
       if (!this.isFirstTypeNew()) {
@@ -222,7 +222,7 @@ export class AddAlgorithmRelationDialogComponent implements OnInit {
   pushNewRelationType(type): void {
     this.stateGroups.unshift({
       optionName: 'New Algorithm-Relation',
-      algoRelationTypes: [type],
+      algorithmRelationTypes: [type],
     });
   }
 
@@ -249,5 +249,5 @@ export interface DialogData {
 
 export interface StateGroup {
   optionName: string;
-  algoRelationTypes: AlgorithmRelationTypeDto[];
+  algorithmRelationTypes: AlgorithmRelationTypeDto[];
 }


### PR DESCRIPTION
Supporting inverseTypeName of AlgoRelationTypes in Atlas.
Further, fix delete relatedAlgorithm error.
Considers #148 