### PR TITLE
Feature/algorithm implementation relation

### DIFF
--- a/generated/api-atlas/models/classic-implementation-dto.ts
+++ b/generated/api-atlas/models/classic-implementation-dto.ts
@@ -3,7 +3,6 @@ import { ClassicAlgorithmDto } from './classic-algorithm-dto';
 import { SoftwarePlatformDto } from './software-platform-dto';
 export type ClassicImplementationDto = {
   id: string;
-  implementedAlgorithmId?: string;
   name: string;
   inputFormat?: string;
   outputFormat?: string;

--- a/generated/api-atlas/models/page-algorithm-dto.ts
+++ b/generated/api-atlas/models/page-algorithm-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageAlgorithmDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<AlgorithmDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<AlgorithmDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-algorithm-relation-dto.ts
+++ b/generated/api-atlas/models/page-algorithm-relation-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageAlgorithmRelationDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<AlgorithmRelationDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<AlgorithmRelationDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-algorithm-relation-type-dto.ts
+++ b/generated/api-atlas/models/page-algorithm-relation-type-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageAlgorithmRelationTypeDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<AlgorithmRelationTypeDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<AlgorithmRelationTypeDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-application-area-dto.ts
+++ b/generated/api-atlas/models/page-application-area-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageApplicationAreaDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ApplicationAreaDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ApplicationAreaDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-cloud-service-dto.ts
+++ b/generated/api-atlas/models/page-cloud-service-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageCloudServiceDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<CloudServiceDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<CloudServiceDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-compute-resource-dto.ts
+++ b/generated/api-atlas/models/page-compute-resource-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageComputeResourceDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ComputeResourceDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ComputeResourceDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-compute-resource-property-dto.ts
+++ b/generated/api-atlas/models/page-compute-resource-property-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageComputeResourcePropertyDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ComputeResourcePropertyDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ComputeResourcePropertyDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-compute-resource-property-type-dto.ts
+++ b/generated/api-atlas/models/page-compute-resource-property-type-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageComputeResourcePropertyTypeDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ComputeResourcePropertyTypeDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ComputeResourcePropertyTypeDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-discussion-comment-dto.ts
+++ b/generated/api-atlas/models/page-discussion-comment-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageDiscussionCommentDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<DiscussionCommentDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<DiscussionCommentDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-discussion-topic-dto.ts
+++ b/generated/api-atlas/models/page-discussion-topic-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageDiscussionTopicDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<DiscussionTopicDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<DiscussionTopicDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-implementation-dto.ts
+++ b/generated/api-atlas/models/page-implementation-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageImplementationDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ImplementationDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ImplementationDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-implementation-package-dto.ts
+++ b/generated/api-atlas/models/page-implementation-package-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageImplementationPackageDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ImplementationPackageDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ImplementationPackageDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-learning-method-dto.ts
+++ b/generated/api-atlas/models/page-learning-method-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageLearningMethodDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<LearningMethodDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<LearningMethodDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-pattern-relation-dto.ts
+++ b/generated/api-atlas/models/page-pattern-relation-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PagePatternRelationDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<PatternRelationDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<PatternRelationDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-pattern-relation-type-dto.ts
+++ b/generated/api-atlas/models/page-pattern-relation-type-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PagePatternRelationTypeDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<PatternRelationTypeDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<PatternRelationTypeDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-problem-type-dto.ts
+++ b/generated/api-atlas/models/page-problem-type-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageProblemTypeDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<ProblemTypeDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<ProblemTypeDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-publication-dto.ts
+++ b/generated/api-atlas/models/page-publication-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PagePublicationDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<PublicationDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<PublicationDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-revision-dto.ts
+++ b/generated/api-atlas/models/page-revision-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageRevisionDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<RevisionDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<RevisionDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-software-platform-dto.ts
+++ b/generated/api-atlas/models/page-software-platform-dto.ts
@@ -5,13 +5,13 @@ import { Sort } from './sort';
 export type PageSoftwarePlatformDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<SoftwarePlatformDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<SoftwarePlatformDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/page-tag-dto.ts
+++ b/generated/api-atlas/models/page-tag-dto.ts
@@ -5,13 +5,13 @@ import { TagDto } from './tag-dto';
 export type PageTagDto = {
   totalPages?: number;
   totalElements?: number;
-  first?: boolean;
   pageable?: Pageable;
-  size?: number;
-  content?: Array<TagDto>;
-  number?: number;
+  first?: boolean;
   sort?: Sort;
+  number?: number;
   numberOfElements?: number;
   last?: boolean;
+  size?: number;
+  content?: Array<TagDto>;
   empty?: boolean;
 };

--- a/generated/api-atlas/models/quantum-implementation-dto.ts
+++ b/generated/api-atlas/models/quantum-implementation-dto.ts
@@ -2,7 +2,6 @@
 import { SoftwarePlatformDto } from './software-platform-dto';
 export type QuantumImplementationDto = {
   id: string;
-  implementedAlgorithmId?: string;
   name: string;
   inputFormat?: string;
   outputFormat?: string;

--- a/generated/api-atlas/services/implementations.service.ts
+++ b/generated/api-atlas/services/implementations.service.ts
@@ -8,6 +8,7 @@ import { RequestBuilder } from '../request-builder';
 import { Observable } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 
+import { AlgorithmDto } from '../models/algorithm-dto';
 import { ImplementationDto } from '../models/implementation-dto';
 import { PageImplementationDto } from '../models/page-implementation-dto';
 import { PageRevisionDto } from '../models/page-revision-dto';
@@ -173,6 +174,130 @@ export class ImplementationsService extends BaseService {
         (r: StrictHttpResponse<ImplementationDto>) =>
           r.body as ImplementationDto
       )
+    );
+  }
+
+  /**
+   * Path part for operation linkAlgorithmAndImplementation
+   */
+  static readonly LinkAlgorithmAndImplementationPath =
+    '/implementations/{implementationId}/algorithms';
+
+  /**
+   * Add a reference to an existing implementation (that was previously created via a POST on e.g. /implementations). Only the ID is required in the request body, other attributes will be ignored and not changed.
+   *
+   * This method provides access to the full `HttpResponse`, allowing access to response headers.
+   * To access only the response body, use `linkAlgorithmAndImplementation()` instead.
+   *
+   * This method sends `application/json` and handles request body of type `application/json`.
+   */
+  linkAlgorithmAndImplementation$Response(params: {
+    implementationId: string;
+    body: AlgorithmDto;
+  }): Observable<StrictHttpResponse<ImplementationDto>> {
+    const rb = new RequestBuilder(
+      this.rootUrl,
+      ImplementationsService.LinkAlgorithmAndImplementationPath,
+      'post'
+    );
+    if (params) {
+      rb.path('implementationId', params.implementationId, {});
+
+      rb.body(params.body, 'application/json');
+    }
+    return this.http
+      .request(
+        rb.build({
+          responseType: 'json',
+          accept: 'application/hal+json',
+        })
+      )
+      .pipe(
+        filter((r: any) => r instanceof HttpResponse),
+        map((r: HttpResponse<any>) => {
+          return r as StrictHttpResponse<ImplementationDto>;
+        })
+      );
+  }
+
+  /**
+   * Add a reference to an existing implementation (that was previously created via a POST on e.g. /implementations). Only the ID is required in the request body, other attributes will be ignored and not changed.
+   *
+   * This method provides access to only to the response body.
+   * To access the full response (for headers, for example), `linkAlgorithmAndImplementation$Response()` instead.
+   *
+   * This method sends `application/json` and handles request body of type `application/json`.
+   */
+  linkAlgorithmAndImplementation(params: {
+    implementationId: string;
+    body: AlgorithmDto;
+  }): Observable<ImplementationDto> {
+    return this.linkAlgorithmAndImplementation$Response(params).pipe(
+      map(
+        (r: StrictHttpResponse<ImplementationDto>) =>
+          r.body as ImplementationDto
+      )
+    );
+  }
+
+  /**
+   * Path part for operation unlinkImplementationAndAlgorithm
+   */
+  static readonly UnlinkImplementationAndAlgorithmPath =
+    '/implementations/{implementationId}/algorithms/{algorithmId}';
+
+  /**
+   * Delete a reference to a implementation of an algorithm.
+   *
+   * This method provides access to the full `HttpResponse`, allowing access to response headers.
+   * To access only the response body, use `unlinkImplementationAndAlgorithm()` instead.
+   *
+   * This method doesn't expect any request body.
+   */
+  unlinkImplementationAndAlgorithm$Response(params: {
+    implementationId: string;
+    algorithmId: string;
+  }): Observable<StrictHttpResponse<void>> {
+    const rb = new RequestBuilder(
+      this.rootUrl,
+      ImplementationsService.UnlinkImplementationAndAlgorithmPath,
+      'delete'
+    );
+    if (params) {
+      rb.path('implementationId', params.implementationId, {});
+      rb.path('algorithmId', params.algorithmId, {});
+    }
+    return this.http
+      .request(
+        rb.build({
+          responseType: 'text',
+          accept: '*/*',
+        })
+      )
+      .pipe(
+        filter((r: any) => r instanceof HttpResponse),
+        map((r: HttpResponse<any>) => {
+          return (r as HttpResponse<any>).clone({
+            body: undefined,
+          }) as StrictHttpResponse<void>;
+        })
+      );
+  }
+
+  /**
+   * Delete a reference to a implementation of an algorithm.
+   *
+   * This method provides access to only to the response body.
+   * To access the full response (for headers, for example), `unlinkImplementationAndAlgorithm$Response()` instead.
+   *
+   * This method doesn't expect any request body.
+   */
+  unlinkImplementationAndAlgorithm(params: {
+    implementationId: string;
+    algorithmId: string;
+  }): Observable<void> {
+    return this.unlinkImplementationAndAlgorithm$Response(params).pipe(
+      map((r: StrictHttpResponse<void>) => r.body as void)
     );
   }
 

--- a/src/app/components/algorithms/algorithm-implementations-list/algorithm-implementations-list.component.html
+++ b/src/app/components/algorithms/algorithm-implementations-list/algorithm-implementations-list.component.html
@@ -8,7 +8,7 @@
                [pagination]=pagingInfo
                [paginatorConfig]=paginatorConfig
                [emptyTableMessage]="'No implementations for this algorithm found'"
-               (addElement)="onAddImplementation()"
+               (addElement)="onOpenImplementationDialog()"
                (submitDeleteElements)="onDeleteImplementation($event)"
                (pageChange)="onDatalistConfigChanged($event)"
                (datalistConfigChanged)="onDatalistConfigChanged($event)"

--- a/src/app/components/algorithms/algorithm-implementations-list/algorithm-implementations-list.component.ts
+++ b/src/app/components/algorithms/algorithm-implementations-list/algorithm-implementations-list.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { AlgorithmDto } from 'api-atlas/models/algorithm-dto';
 import { UtilService } from '../../../util/util.service';
-import { CreateImplementationDialogComponent } from '../dialogs/create-implementation-dialog.component';
+import { ChoiceImplementationDialogComponent } from '../dialogs/choice-implementation-dialog.component';
 import { ConfirmDialogComponent } from '../../generics/dialogs/confirm-dialog.component';
 
 @Component({
@@ -55,45 +55,6 @@ export class AlgorithmImplementationsListComponent implements OnInit {
     this.pagingInfo.totalPages = implementations.totalPages;
     this.pagingInfo.number = implementations.number;
     this.pagingInfo.sort = implementations.sort;
-  }
-
-  onAddImplementation(): void {
-    this.utilService
-      .createDialog(CreateImplementationDialogComponent, {
-        title: 'Add new implementation for this algorithm',
-      })
-      .afterClosed()
-      .subscribe((dialogResult) => {
-        if (dialogResult) {
-          const implementationDto: ImplementationDto = {
-            id: null,
-            name: dialogResult.name,
-          };
-          this.algorithmService
-            .createImplementation({
-              algorithmId: this.algorithm.id,
-              body: implementationDto,
-            })
-            .subscribe(
-              (data) => {
-                this.router.navigate([
-                  'algorithms',
-                  data.implementedAlgorithmId,
-                  'implementations',
-                  data.id,
-                ]);
-                this.utilService.callSnackBar(
-                  'Implementation was successfully created.'
-                );
-              },
-              () => {
-                this.utilService.callSnackBar(
-                  'Error! Implementation could not be created.'
-                );
-              }
-            );
-        }
-      });
   }
 
   onDeleteImplementation(event): void {
@@ -159,6 +120,46 @@ export class AlgorithmImplementationsListComponent implements OnInit {
             );
             this.utilService.callSnackBarSequence(snackbarMessages);
           });
+        }
+      });
+  }
+
+  onOpenImplementationDialog(): void {
+    this.utilService
+      .createDialog(ChoiceImplementationDialogComponent, {
+        title: 'Create/Link implementation for this algorithm',
+      })
+      .afterClosed()
+      .subscribe((dialogResult) => {
+        if (dialogResult) {
+          const implementationDto: ImplementationDto = {
+            id: null,
+            name: dialogResult.name,
+          };
+          this.algorithmService
+            .createImplementation({
+              algorithmId: this.algorithm.id,
+              body: implementationDto,
+            })
+            .subscribe(
+              (data) => {
+                console.log(data);
+                this.router.navigate([
+                  'algorithms',
+                  this.algorithm.id,
+                  'implementations',
+                  data.id,
+                ]);
+                this.utilService.callSnackBar(
+                  'Implementation was successfully created.'
+                );
+              },
+              () => {
+                this.utilService.callSnackBar(
+                  'Error! Implementation could not be created.'
+                );
+              }
+            );
         }
       });
   }

--- a/src/app/components/algorithms/algorithm.module.ts
+++ b/src/app/components/algorithms/algorithm.module.ts
@@ -13,7 +13,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatTreeModule } from '@angular/material/tree';
-import { CardsModule } from 'angular-bootstrap-md';
+import { CardsModule, MDBBootstrapModule } from 'angular-bootstrap-md';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatTableModule } from '@angular/material/table';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -32,6 +32,7 @@ import { AlgorithmRelatedAlgosListComponent } from './algorithm-related-algos-li
 import { AlgorithmPropertiesComponent } from './algorithm-properties/algorithm-properties.component';
 import { AlgorithmPublicationsListComponent } from './algorithm-publications-list/algorithm-publications-list.component';
 import { AddAlgorithmDialogComponent } from './dialogs/add-algorithm-dialog.component';
+import { ChoiceImplementationDialogComponent } from './dialogs/choice-implementation-dialog.component';
 import { CreateImplementationDialogComponent } from './dialogs/create-implementation-dialog.component';
 import { ProblemTypeTreeComponent } from './problem-type-tree/problem-type-tree.component';
 import { AlgorithmRelatedPatternsComponent } from './algorithm-related-patterns/algorithm-related-patterns.component';
@@ -51,6 +52,7 @@ import { AddNewAnalysisDialogComponent } from './dialogs/add-new-analysis-dialog
     AlgorithmPublicationsListComponent,
     ProblemTypeTreeComponent,
     AddAlgorithmDialogComponent,
+    ChoiceImplementationDialogComponent,
     CreateImplementationDialogComponent,
     AlgorithmRelatedPatternsComponent,
     AddPatternRelationDialogComponent,
@@ -87,6 +89,7 @@ import { AddNewAnalysisDialogComponent } from './dialogs/add-new-analysis-dialog
     MatSortModule,
     QcAtlasUiFeatureToggleModule,
     MatBadgeModule,
+    MDBBootstrapModule,
   ],
   exports: [
     AlgorithmListComponent,
@@ -97,7 +100,7 @@ import { AddNewAnalysisDialogComponent } from './dialogs/add-new-analysis-dialog
     AlgorithmPublicationsListComponent,
     ProblemTypeTreeComponent,
     AddAlgorithmDialogComponent,
-    CreateImplementationDialogComponent,
+    ChoiceImplementationDialogComponent,
     AddPatternRelationDialogComponent,
     AddAlgorithmRelationDialogComponent,
     ImplementationPropertiesComponent,

--- a/src/app/components/algorithms/dialogs/choice-implementation-dialog.component.html
+++ b/src/app/components/algorithms/dialogs/choice-implementation-dialog.component.html
@@ -1,0 +1,19 @@
+<h1 mat-dialog-title>{{data.title}}</h1>
+<div mat-dialog-actions>
+  <div>
+    <button mdbBtn class="btn-sm"
+            type="button" color="green" outline="true"
+            (click)="onCreateImplementationDialog()"
+            mdbWavesEffect>
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
+    <button mdbBtn class="btn-sm"
+            type="button" color="blue" outline="true"
+            (click)="openLinkImplementationDialog()"
+            mdbWavesEffect>
+      <mat-icon>link</mat-icon>
+    </button>
+  </div>
+  <div>
+</div>

--- a/src/app/components/algorithms/dialogs/choice-implementation-dialog.component.scss
+++ b/src/app/components/algorithms/dialogs/choice-implementation-dialog.component.scss
@@ -1,0 +1,7 @@
+.add-button:hover {
+  background-color: green !important;
+}
+
+.link-button:hover {
+  background-color: blue !important;
+}

--- a/src/app/components/algorithms/dialogs/choice-implementation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/choice-implementation-dialog.component.ts
@@ -1,0 +1,255 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { AlgorithmDto } from 'api-atlas/models/algorithm-dto';
+import { forkJoin, Observable } from 'rxjs';
+import { ImplementationsService } from 'api-atlas/services/implementations.service';
+import { PageImplementationDto } from 'api-atlas/models/page-implementation-dto';
+import { Router } from '@angular/router';
+import { ImplementationDto } from 'api-atlas/models/implementation-dto';
+import { AlgorithmService } from 'api-atlas/services/algorithm.service';
+import {
+  LinkObject,
+  QueryParams,
+} from '../../generics/data-list/data-list.component';
+import {
+  DialogData,
+  LinkItemListDialogComponent,
+} from '../../generics/dialogs/link-item-list-dialog.component';
+import { UtilService } from '../../../util/util.service';
+import { CreateImplementationDialogComponent } from './create-implementation-dialog.component';
+
+@Component({
+  selector: 'app-choice-implementation-dialog',
+  templateUrl: './choice-implementation-dialog.component.html',
+  styleUrls: ['./choice-implementation-dialog.component.scss'],
+})
+export class ChoiceImplementationDialogComponent implements OnInit {
+  @Input() algorithm: AlgorithmDto;
+  implementationForm: FormGroup;
+  pagingInfo: any = {};
+  displayedData = [];
+  linkObject: LinkObject = {
+    title: 'Link implementation with ',
+    subtitle: 'Search implementations by name',
+    displayVariable: 'name',
+    data: [],
+    linkedData: [],
+  };
+  dialogData: DialogData = {
+    title: 'Link existing implementation',
+    linkObject: this.linkObject,
+    tableColumns: ['Name'],
+    variableNames: ['name'],
+    noButtonText: 'Cancel',
+    pagingInfo: {},
+    paginatorConfig: {
+      amountChoices: [10, 25, 50],
+      selectedAmount: 10,
+    },
+  };
+
+  constructor(
+    public dialogRef: MatDialogRef<ChoiceImplementationDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ImplementationChoiceDialogData,
+    public dialog: MatDialog,
+    private utilService: UtilService,
+    private implementationsService: ImplementationsService,
+    private algorithmService: AlgorithmService,
+    private router: Router
+  ) {}
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  ngOnInit(): void {}
+
+  onCreateImplementationDialog(): void {
+    this.utilService
+      .createDialog(CreateImplementationDialogComponent, {
+        title: 'Create implementation for this algorithm',
+      })
+      .afterClosed()
+      .subscribe((createImplementationDialogResult) => {
+        this.dialogRef.close(createImplementationDialogResult);
+      });
+  }
+
+  getImplementationsOfAlgorithm(params: QueryParams = {}): void {
+    this.linkObject.linkedData = [];
+    this.algorithmService
+      .getImplementationsOfAlgorithm({
+        algorithmId: this.algorithm.id,
+        search: params.search,
+        page: params.page,
+        sort: params.sort,
+        size: params.size,
+      })
+      .subscribe(
+        (data) => {
+          if (data.content) {
+            this.linkObject.linkedData = data.content;
+          }
+          this.updateDisplayedData(data);
+        },
+        () => {
+          this.utilService.callSnackBar(
+            'Error! Linked implementations could not be retrieved.'
+          );
+        }
+      );
+  }
+
+  getAllImplementations(
+    search?: QueryParams
+  ): Observable<PageImplementationDto> {
+    return this.implementationsService
+      .getImplementations(search)
+      .pipe((data) => data);
+  }
+
+  updateLinkDialogData(data): void {
+    // clear link object data
+    this.linkObject.data = [];
+    // If publications found
+    if (data.content) {
+      this.linkObject.data = data.content;
+    }
+    this.dialogData.pagingInfo.totalPages = data.totalPages;
+    this.dialogData.pagingInfo.number = data.number;
+    this.dialogData.pagingInfo.size = data.size;
+    this.dialogData.pagingInfo.sort = data.sort;
+  }
+
+  openLinkImplementationDialog(): void {
+    this.getAllImplementations().subscribe((data) => {
+      this.updateLinkDialogData(data);
+      const dialogRef = this.utilService.createDialog(
+        LinkItemListDialogComponent,
+        this.dialogData,
+        1000,
+        700
+      );
+      const searchTextSub = dialogRef.componentInstance.onDataListConfigChanged.subscribe(
+        (search: QueryParams) => {
+          this.getAllImplementations(search).subscribe((updatedData) => {
+            this.updateLinkDialogData(updatedData);
+            dialogRef.componentInstance.data.linkObject = this.linkObject;
+          });
+        }
+      );
+      const pagingSub = dialogRef.componentInstance.onPageChanged.subscribe(
+        (page: QueryParams) => {
+          this.getAllImplementations(page).subscribe((pageData) => {
+            this.updateLinkDialogData(pageData);
+            dialogRef.componentInstance.data.linkObject = this.linkObject;
+          });
+        }
+      );
+      const elementClickedSub = dialogRef.componentInstance.onElementClicked.subscribe(
+        (element: ImplementationDto) => {
+          this.routeToImplementation(element);
+          dialogRef.close();
+        }
+      );
+
+      dialogRef.afterClosed().subscribe((dialogResult) => {
+        searchTextSub.unsubscribe();
+        pagingSub.unsubscribe();
+        elementClickedSub.unsubscribe();
+        if (dialogResult) {
+          this.linkPublications(dialogResult.selectedItems);
+        }
+      });
+    });
+  }
+
+  updateDisplayedData(data): void {
+    // clear link object data
+    this.displayedData = [];
+    // If publications found
+    if (data.content) {
+      this.displayedData = data.content;
+    }
+    this.pagingInfo.totalPages = data.totalPages;
+    this.pagingInfo.totalElements = data.totalElements;
+    this.pagingInfo.number = data.number;
+    this.pagingInfo.size = data.size;
+    this.pagingInfo.sort = data.sort;
+    this.pagingInfo.search = data.search;
+  }
+
+  linkPublications(implementations: ImplementationDto[]): void {
+    // Empty unlinked publications
+    this.linkObject.data = [];
+    const linkTasks = [];
+    const snackbarMessages = [];
+    let successfulLinks = 0;
+    for (const implementation of implementations) {
+      linkTasks.push(
+        this.implementationsService
+          .linkAlgorithmAndImplementation({
+            implementationId: implementation.id,
+            body: this.algorithm,
+          })
+          .toPromise()
+          .then(() => {
+            successfulLinks++;
+            snackbarMessages.push(
+              'Successfully linked implementation "' +
+                implementation.name +
+                '".'
+            );
+          })
+          .catch(() => {
+            snackbarMessages.push(
+              'Error! Could not link implementation "' +
+                implementation.name +
+                '".'
+            );
+          })
+      );
+    }
+    forkJoin(linkTasks).subscribe(() => {
+      const correctPage = this.utilService.getLastPageAfterCreation(
+        this.pagingInfo,
+        successfulLinks
+      );
+      const parameters: QueryParams = {
+        size: this.pagingInfo.size,
+        page: correctPage,
+        sort: this.pagingInfo.sort,
+        search: this.pagingInfo.search,
+      };
+      this.getImplementationsOfAlgorithm(parameters);
+      snackbarMessages.push(
+        this.utilService.generateFinishingSnackbarMessage(
+          successfulLinks,
+          implementations.length,
+          'implementations',
+          'linked'
+        )
+      );
+      this.utilService.callSnackBarSequence(snackbarMessages);
+    });
+  }
+
+  routeToImplementation(implementation: ImplementationDto): void {
+    this.router.navigate([
+      'algorithms',
+      this.algorithm.id,
+      'implementations',
+      implementation.id,
+    ]);
+  }
+}
+
+export interface ImplementationChoiceDialogData {
+  name: string;
+  title: string;
+}

--- a/src/app/components/algorithms/dialogs/create-implementation-dialog.component.ts
+++ b/src/app/components/algorithms/dialogs/create-implementation-dialog.component.ts
@@ -21,7 +21,7 @@ export class CreateImplementationDialogComponent implements OnInit {
 
   constructor(
     public dialogRef: MatDialogRef<CreateImplementationDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: DialogData,
+    @Inject(MAT_DIALOG_DATA) public data: CreateDialogData,
     public dialog: MatDialog
   ) {}
 
@@ -52,7 +52,7 @@ export class CreateImplementationDialogComponent implements OnInit {
   }
 }
 
-export interface DialogData {
+export interface CreateDialogData {
   title: string;
   name: string;
 }


### PR DESCRIPTION
#### Short Description
Integrates [PR-193](https://github.com/UST-QuAntiL/qc-atlas/pull/193).

#### Proposed Changes
  * Adds new dialog to choose between creating a new implementation for an algorithm or link an existing implementation
  * Adds a generic link dialog to link an existing implementation
  * Adds a dialog to create a new implementation for an algorithm 
  * Regenerates models & services

#### ToDo's
- [ ] Use _algorithm.id_ in the general views when referring to an algorithm id (_implementation.implementedAlgorithmId is obsolet_).
- [ ] Let the algorithm-implementation component handle the data for linking an existing implementation or combine the dialogs in only one dialog