### PR TITLE
Update impl-selection-criteria.component.html

### DIFF
--- a/src/app/components/algorithms/impl-selection-criteria/impl-selection-criteria.component.html
+++ b/src/app/components/algorithms/impl-selection-criteria/impl-selection-criteria.component.html
@@ -56,7 +56,7 @@
         aria-label="Remove selected parameters"
         (click)="deleteMany()"
       >
-        <mat-icon>remove</mat-icon>
+        <mat-icon>delete</mat-icon>
       </button>
     </div>
   </div>

--- a/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.html
+++ b/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.html
@@ -341,23 +341,23 @@
                                     *matCellDef="let element"
                                     [attr.colspan]="analyzeColumns.length"
                             >
-                                <div class="element-detail" *ngIf="element == expandedElement">
-                                    <ng-container *ngIf="expandedElementExecResult">
+                                <div class="element-detail" *ngIf="expandedElementMap.has(element)">
+                                    <ng-container *ngIf="expandedElementMap.get(element)">
                                         <div class="p-2" style="margin-left: auto">
                                             <div style="text-align: right">
-                                                Status: {{ expandedElementExecResult.status }}</div>
+                                                Status: {{ expandedElementMap.get(element).status }}</div>
                                             <div style="text-align: right">Number of
-                                                shots: {{ expandedElementExecResult.shots === 0 ?
-                                                    '-' : expandedElementExecResult.shots}}
+                                                shots: {{ expandedElementMap.get(element).shots === 0 ?
+                                                    '-' : expandedElementMap.get(element).shots}}
                                             </div>
                                             <div style="text-align: right">Histogram intersection value:
                                                 <code>
-                                                    {{expandedElementExecResult.histogramIntersectionValue === 0 ?
-                                                    '-' : expandedElementExecResult.histogramIntersectionValue}}
+                                                    {{expandedElementMap.get(element).histogramIntersectionValue === 0 ?
+                                                    '-' : expandedElementMap.get(element).histogramIntersectionValue}}
                                                 </code>
                                             </div>
                                             <div style="text-align: right">Result:
-                                                <code>{{ expandedElementExecResult.result || 'n/a' }}</code></div>
+                                                <code>{{ expandedElementMap.get(element).result || 'n/a' }}</code></div>
                                         </div>
                                     </ng-container>
                                 </div>

--- a/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
@@ -269,7 +269,7 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
 
         for (const analysisResult of this.analyzerResults) {
           this.showBackendQueueSize(analysisResult);
-          setInterval(() => this.showBackendQueueSize(analysisResult), 30000);
+          setInterval(() => this.showBackendQueueSize(analysisResult), 300000);
           this.hasExecutionResult(analysisResult);
           this.checkIfQpuDataIsOutdated(analysisResult);
         }

--- a/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
@@ -104,6 +104,10 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
   executionResultsAvailable = new Map<string, boolean>();
   loadingResults = new Map<string, boolean>();
   expandedElement: QpuSelectionResultDto | null;
+  expandedElementMap: Map<QpuSelectionResultDto, ExecutionResultDto> = new Map<
+    QpuSelectionResultDto,
+    ExecutionResultDto
+  >();
   expandedElementExecResult: ExecutionResultDto | null;
   executedAnalyseResult: QpuSelectionResultDto;
   results?: ExecutionResultDto = undefined;
@@ -318,7 +322,8 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
   }
 
   showExecutionResult(analysisResult: QpuSelectionResultDto): void {
-    if (Object.is(this.expandedElement, analysisResult)) {
+    if (this.expandedElementMap.has(analysisResult)) {
+      this.expandedElementMap.delete(analysisResult);
       this.expandedElement = undefined;
       this.expandedElementExecResult = undefined;
       return;
@@ -332,10 +337,13 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
         const href = result._links[key].href;
         this.http.get<ExecutionResultDto>(href).subscribe((dto) => {
           this.expandedElement = analysisResult;
+          this.expandedElementMap.set(analysisResult, dto);
           this.expandedElementExecResult = dto;
         });
       });
   }
+
+  // getExpandedElementDetails(element: QpuSelectionResultDto) {}
 
   refreshNisqImpl(): void {
     this.implementationService

--- a/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
@@ -344,8 +344,6 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
       });
   }
 
-  // getExpandedElementDetails(element: QpuSelectionResultDto) {}
-
   refreshNisqImpl(): void {
     this.implementationService
       .getImplementations({ algoId: this.algo.id })

--- a/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
@@ -269,6 +269,7 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
 
         for (const analysisResult of this.analyzerResults) {
           this.showBackendQueueSize(analysisResult);
+          setInterval(() => this.showBackendQueueSize(analysisResult), 60000);
           this.hasExecutionResult(analysisResult);
           this.checkIfQpuDataIsOutdated(analysisResult);
         }

--- a/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
+++ b/src/app/components/algorithms/implementation-view/implementation-nisq-analyzer-qpu-selection/implementation-nisq-analyzer-qpu-selection.component.ts
@@ -269,7 +269,7 @@ export class ImplementationNisqAnalyzerQpuSelectionComponent
 
         for (const analysisResult of this.analyzerResults) {
           this.showBackendQueueSize(analysisResult);
-          setInterval(() => this.showBackendQueueSize(analysisResult), 60000);
+          setInterval(() => this.showBackendQueueSize(analysisResult), 30000);
           this.hasExecutionResult(analysisResult);
           this.checkIfQpuDataIsOutdated(analysisResult);
         }


### PR DESCRIPTION
Under Selection criteria > Input Parameters show a trash can instead of the minus symbol when the user selects a given parameter.

Currently when an execution result is presented in the table and the user clicks on another execution result, the other automatically closes.
The user should be able to compare the execution results of multiple QPUs, thus, multiple should be openable in parallel.

In the QPU-Selection Analysis results table the current queue size of each QPU is presented.
Call the IBMQ API again after 10 minutes when the table is still open.